### PR TITLE
Fix not needed includes of romfiles.h

### DIFF
--- a/inc/niffs/nffs.h
+++ b/inc/niffs/nffs.h
@@ -2,7 +2,6 @@
 #include "romfs.h"
 #include <string.h>
 #include <errno.h>
-#include "romfiles.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include "ioctl.h"

--- a/src/niffs/niffs.c
+++ b/src/niffs/niffs.c
@@ -2,7 +2,6 @@
 #include "romfs.h"
 #include <string.h>
 #include <errno.h>
-#include "romfiles.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include "ioctl.h"


### PR DESCRIPTION
Including romfiles.h in source files that don't need it in a regular
(source based) build is benign, but it produces warnings in an
object-file based build. Those warnings are also benign, but it's better
to remove them completely.