### PR TITLE
Added user init function

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -85,6 +85,13 @@ extern void extras_init_early();
 extern void extras_exit();
 #endif
 
+// Define a weak symbol for an user init function which is called during startup
+// The user code can override this function with a regular (non-weak) symbol.
+void __attribute__((weak)) elua_user_init( void )
+{
+
+}
+
 int main( void )
 {
   int i;
@@ -124,6 +131,9 @@ int main( void )
   // Init Extras
   extras_init();
 #endif
+
+  // User-specific initialization code
+  elua_user_init();
 
   // Search for autorun files in the defined order and execute the 1st if found
   for( i = 0; i < sizeof( boot_order ) / sizeof( *boot_order ); i++ )


### PR DESCRIPTION
The user code can now define a init function called "elua_user_init"
that will be called as part of main(). The default implementation of
this function is defined as a weak symbol in src/main.c and does
nothing.