### PR TITLE
(1/2) Init functions improvements

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -72,17 +72,27 @@ void boot_rpc( void )
 // ****************************************************************************
 //  Program entry point
 
-// Define a weak symbol for an user init function which is called during startup
-// The user code can override this function with a regular (non-weak) symbol.
-// Suggested use is printing startup data, if the board is booting up and not going back to sleep.
-void __attribute__((weak)) elua_user_init( void )
-{
-}
-
 // Define a weak symbol for a very early user init function which is called during startup
 // The user code can override this function with a regular (non-weak) symbol.
 // Suggested use is setup of I/O's, timers, and very fast checking of sleep states.
 void __attribute__((weak)) elua_user_init_early( void )
+{
+}
+
+// Define a weak symbol for an user init function which is called during startup, after
+// all the regular eLua initialization code, before the Lua interpreter starts.
+// The user code can override this function with a regular (non-weak) symbol.
+// Suggested use is finishing all the platform-specific initialization tasks.
+void __attribute__((weak)) elua_user_init_late( void )
+{
+}
+
+// Define a weak symbol for an application-specific user init function which is called during startup
+// The function is called right before the Lua interpreter starts, but after elua_user_init_late (above).
+// The user code can override this function with a regular (non-weak) symbol.
+// Suggested use is printing startup data, if the board is booting up and not going back to sleep,
+// or settings various hoook functions.
+void __attribute__((weak)) elua_app_user_init( void )
 {
 }
 
@@ -132,8 +142,11 @@ int main( void )
   // Register NIFFS
   nffs_init();
 
-  // User-specific initialization code
-  elua_user_init();
+  // Late initialization code
+  elua_user_init_late();
+
+  // Application-specific initialization code
+  elua_app_user_init();
 
   // Search for autorun files in the defined order and execute the 1st if found
   for( i = 0; i < sizeof( boot_order ) / sizeof( *boot_order ); i++ )

--- a/src/platform/sim3u1xx/platform.c
+++ b/src/platform/sim3u1xx/platform.c
@@ -671,12 +671,6 @@ int platform_init()
     }
   }
 
-  // Enable Timer 0
-  gTIMER0_enter_auto_reload_config();
-  // Enable Timer 1
-  gTIMER1_enter_auto_reload_config();
-
-
   buf_set( BUF_ID_RNG, 0, BUF_SIZE_32, BUF_DSIZE_U8 );
 
   // Setup Watchdog Timer
@@ -970,56 +964,6 @@ void SysTick_Handler()
   }
   if(i2c_timeout_timer)
     i2c_timeout_timer--;
-}
-
-static void gTIMER0_enter_auto_reload_config(void)
-{
-  // ENABLE TIMER0 CLOCK
-  SI32_CLKCTRL_A_enable_apb_to_modules_0(SI32_CLKCTRL_0,
-    SI32_CLKCTRL_A_APBCLKG0_TIMER0CEN_ENABLED_U32);
-
-  // INITIALIZE TIMER
-  SI32_TIMER_A_initialize (SI32_TIMER_0, 0x00, 0x00, 0x00, 0x00);
-  SI32_TIMER_A_select_single_timer_mode (SI32_TIMER_0);
-  SI32_TIMER_A_select_high_clock_source_apb_clock (SI32_TIMER_0);
-  SI32_TIMER_A_select_high_auto_reload_mode (SI32_TIMER_0);
-
-  // Set overflow frequency to SYSTICKHZ
-  SI32_TIMER_A_write_capture (SI32_TIMER_0, (unsigned) -(cmsis_get_cpu_frequency()/SYSTICKHZ));
-  SI32_TIMER_A_write_count (SI32_TIMER_0, (unsigned) -(cmsis_get_cpu_frequency()/SYSTICKHZ));
-
-  // Run Timer
-  SI32_TIMER_A_start_high_timer(SI32_TIMER_0);
-
-  // ENABLE INTERRUPTS
-  NVIC_ClearPendingIRQ(TIMER0H_IRQn);
-  NVIC_EnableIRQ(TIMER0H_IRQn);
-  SI32_TIMER_A_enable_high_overflow_interrupt(SI32_TIMER_0);
-}
-
-static void gTIMER1_enter_auto_reload_config(void)
-{
-  // ENABLE TIMER1 CLOCK
-  SI32_CLKCTRL_A_enable_apb_to_modules_0(SI32_CLKCTRL_0,
-    SI32_CLKCTRL_A_APBCLKG0_TIMER1CEN_ENABLED_U32);
-
-  // INITIALIZE TIMER
-  SI32_TIMER_A_initialize (SI32_TIMER_1, 0x00, 0x00, 0x00, 0x00);
-  SI32_TIMER_A_select_single_timer_mode (SI32_TIMER_1);
-  SI32_TIMER_A_select_high_clock_source_apb_clock (SI32_TIMER_1);
-  SI32_TIMER_A_select_high_auto_reload_mode (SI32_TIMER_1);
-
-  // Set overflow frequency to SYSTICKHZ
-  SI32_TIMER_A_write_capture (SI32_TIMER_1, (unsigned) -(cmsis_get_cpu_frequency()/TIMER1_HZ));
-  SI32_TIMER_A_write_count (SI32_TIMER_1, (unsigned) -(cmsis_get_cpu_frequency()/TIMER1_HZ));
-
-  // Run Timer
-  SI32_TIMER_A_start_high_timer(SI32_TIMER_1);
-
-  // ENABLE INTERRUPTS
-  NVIC_ClearPendingIRQ(TIMER1H_IRQn);
-  NVIC_EnableIRQ(TIMER1H_IRQn);
-  SI32_TIMER_A_enable_high_overflow_interrupt(SI32_TIMER_1);
 }
 
 // ****************************************************************************


### PR DESCRIPTION
- Added an application-specific initialization function
`elua_app_user_init` that allows the user to run
application-specific initialization code (as opposed to
platform-specific initialization code)
- Moved the calls that enable TIMER0H_Irq and TIMER1H_Irq at a later
time, after more initializations are complete.