### PR TITLE
(1/2) Fix multiple definitions

### DIFF
--- a/src/platform/sim3u1xx/conf.lua
+++ b/src/platform/sim3u1xx/conf.lua
@@ -59,7 +59,7 @@ addcf{ '-Wno-missing-field-initializers', '-Wshift-overflow=2', '-Wduplicated-co
 addcf{ '-Wno-sign-compare', '-Wno-cast-qual', '-Wno-cast-align', '-Wno-format-nonliteral'}
 -- Testing below for backtrace functionality
 -- addcf{ '-ffunction-sections', '-fdata-sections', '-fno-strict-aliasing', '-Wall' , '-mtpcs-frame', '-mtpcs-leaf-frame', '-fno-omit-frame-pointer' }
-addlf{ '-nostartfiles', '-nostdlib', '-T', ldscript, '-Wl,--gc-sections', '-Wl,--allow-multiple-definition' }
+addlf{ '-nostartfiles', '-nostdlib', '-T', ldscript, '-Wl,--gc-sections' }
 addaf{ '-x', 'assembler-with-cpp', '-Wall' }
 addlib{ 'c','gcc','m' }
 

--- a/src/platform/sim3u1xx/cpu_sim3u167.h
+++ b/src/platform/sim3u1xx/cpu_sim3u167.h
@@ -14,7 +14,12 @@ extern unsigned platform_get_console_uart( void );
 
 #define TIMER1_HZ 1800 //High priority timer for uarts = 115200/8/1800 = 4 bytes per tick for ~57600 bps (BLE speed)
 
-SI32_PBSTD_A_Type* const port_std[] = { SI32_PBSTD_0, SI32_PBSTD_1, SI32_PBSTD_2, SI32_PBSTD_3 };
+#ifdef INSTANTIATE_PORT_STD
+SI32_PBSTD_A_Type* const port_std[ 4 ] = { SI32_PBSTD_0, SI32_PBSTD_1, SI32_PBSTD_2, SI32_PBSTD_3 };
+#undef INSTANTIATE_PORT_STD
+#else
+extern SI32_PBSTD_A_Type* const port_std[ 4 ];
+#endif
 
 #define CON_VIRTUAL_ID 255
 

--- a/src/platform/sim3u1xx/platform.c
+++ b/src/platform/sim3u1xx/platform.c
@@ -1,5 +1,7 @@
 // Platform-dependent functions
 
+#define INSTANTIATE_PORT_STD
+#include "cpu_sim3u167.h"
 #include "platform.h"
 #include "type.h"
 #include "devman.h"
@@ -268,21 +270,6 @@ void WDTIMER0_IRQHandler(void)
 #if defined( BUILD_USB_CDC )
 unsigned console_cdc_active = 0;
 #endif
-
-
-
-// SiM3 SystemInit calls this function, disable watchdog timer
-void mySystemInit(void)
-{
-  // Setup Watchdog Timer
-  SI32_WDTIMER_A_stop_counter(SI32_WDTIMER_0);
-
-  // enable APB clock to the Port Bank module
-  SI32_CLKCTRL_A_enable_apb_to_modules_0 (SI32_CLKCTRL_0, SI32_CLKCTRL_A_APBCLKG0_PB0CEN_MASK);
-  // make the SWO pin (PB1.3) push-pull to enable SWV printf
-  //SI32_PBSTD_A_set_pins_push_pull_output (SI32_PBSTD_1, (1<<3));
-
-}
 
 #if defined( ELUA_BOARD_GSATMICRO_V10 )
 
@@ -2643,7 +2630,6 @@ void sim3_pbhd_setdrivestrength( unsigned state, int pin )
 // Flash access functions
 
 volatile u8 platform_flash_key_mask = 0x00;
-volatile u8 armed_flash_key = 0x00;
 
 u8 flash_erase( u32 address, u8 verify)
 {


### PR DESCRIPTION
By default, eLua instructs the linker to accept multiple symbol
definitions. This means that if a symbol named `A` is defined in two
objects `O1` and `O2` the linker will use both of these definitions
instead of complaining that `A` is defined multiple times (which is the
default linker behaviour). This is problematic for a number of reasons:

- If `A` is a funtion, the programmer will have no way to know that some
of the functions that he wrote might be defined somewhere else. This
might lead to an incorrect program behaviour.
- If `A` is a variable, multiple copies of `A` will end up in different
object files, which wastes memory and might also lead to an incorrect
program behaviour.

This PR forbids multiple symbol definitions and fixes the multiple
symbol definitions that were found in the code:

- `port_std` defined in `cpu_sim3u167.h` was instantiated multiple
times, now it is instantiated once.
- `mySystemInit` in `platform.c` wasn't used at all (the implementation
in `src/platform/sim3u1xx/FreakUSB/hw/sim3u1xx/hw.c` is used instead).
- `armed_flash_key` in `platform.c` wasn't used at all, but it was
causing "multiple symbol definition" errors.