### PR TITLE
Added critical sections

### DIFF
--- a/inc/platform.h
+++ b/inc/platform.h
@@ -258,6 +258,10 @@ u32 platform_pwm_get_clock( unsigned id );
 
 int platform_cpu_set_global_interrupts( int status );
 int platform_cpu_get_global_interrupts(void);
+void platform_cpu_enter_critical_section(void);
+void platform_s_cpu_enter_critical_section(void);
+void platform_cpu_exit_critical_section(void);
+void platform_s_cpu_exit_critical_section(void);
 int platform_cpu_set_interrupt( elua_int_id id, elua_int_resnum resnum, int status );
 int platform_cpu_get_interrupt( elua_int_id id, elua_int_resnum resnum );
 int platform_cpu_get_interrupt_flag( elua_int_id id, elua_int_resnum resnum, int clear );

--- a/src/buf.c
+++ b/src/buf.c
@@ -160,7 +160,7 @@ int buf_write( unsigned resid, unsigned resnum, t_buf_data *data )
     return PLATFORM_ERR; 
   }
 
-  int old_status = platform_cpu_set_global_interrupts( PLATFORM_CPU_DISABLE );
+  platform_cpu_enter_critical_section();
 
   char* d = ( char* )( pbuf->buf + pbuf->wptr );
 
@@ -171,7 +171,7 @@ int buf_write( unsigned resid, unsigned resnum, t_buf_data *data )
 
   int bufsize = BUF_REALSIZE( pbuf );
 
-  platform_cpu_set_global_interrupts( old_status );
+  platform_cpu_exit_critical_section();
 
   //If this is a UART buffer
   if( resid == BUF_ID_UART || resid == BUF_ID_CONSOLE)
@@ -245,7 +245,7 @@ int buf_read( unsigned resid, unsigned resnum, t_buf_data *data )
   if( pbuf->logsize == BUF_SIZE_NONE || BUF_COUNT( pbuf ) == 0 )
     return PLATFORM_UNDERFLOW;
  
-  int old_status = platform_cpu_set_global_interrupts( PLATFORM_CPU_DISABLE );
+  platform_cpu_enter_critical_section();
 
   DUFF_DEVICE_8( BUF_REALDSIZE( pbuf ),  *d++ = *s++ );
 
@@ -253,7 +253,7 @@ int buf_read( unsigned resid, unsigned resnum, t_buf_data *data )
 
   BUF_MOD_INCR( pbuf, rptr );
 
-  platform_cpu_set_global_interrupts( old_status );
+  platform_cpu_exit_critical_section();
   
   return PLATFORM_OK;
 }

--- a/src/common.c
+++ b/src/common.c
@@ -313,6 +313,28 @@ u32 platform_cpu_get_frequency(void)
   return CPU_FREQUENCY;
 }
 
+static volatile u32 critical_section_reentrancy_counter = 0;
+
+void platform_cpu_enter_critical_section( void )
+{
+  platform_s_cpu_enter_critical_section();
+  ++critical_section_reentrancy_counter;
+}
+
+void platform_cpu_exit_critical_section( void )
+{
+  // If critical_section_enter has not previously been called, do nothing
+  if( critical_section_reentrancy_counter == 0 )
+  {
+    return;
+  }
+  --critical_section_reentrancy_counter;
+  if( critical_section_reentrancy_counter == 0 )
+  {
+    platform_s_cpu_exit_critical_section();
+  }
+}
+
 // ****************************************************************************
 // ADC functions
 

--- a/src/elua_uip.c
+++ b/src/elua_uip.c
@@ -550,7 +550,7 @@ int elua_net_socket( int type )
   if( type == ELUA_NET_SOCK_DGRAM )
     return -1;
 
-  old_status = platform_cpu_set_global_interrupts( PLATFORM_CPU_DISABLE );
+  platform_cpu_enter_critical_section();
   // Iterate through the list of connections, looking for a free one
   for( i = 0; i < UIP_CONNS; i ++ )
   {
@@ -562,7 +562,7 @@ int elua_net_socket( int type )
       break;
     }
   }
-  platform_cpu_set_global_interrupts( old_status );
+  platform_cpu_exit_critical_section();
   return i == UIP_CONNS ? -1 : i;
 }
 
@@ -601,13 +601,13 @@ static elua_net_size elua_net_recv_internal( int s, void* buf, elua_net_size max
       break;
     if( to_us > 0 && platform_timer_get_diff_crt( timer_id, tmrstart ) >= to_us )
     {
-      old_status = platform_cpu_set_global_interrupts( PLATFORM_CPU_DISABLE );
+      platform_cpu_enter_critical_section();
       if( pstate->state != ELUA_UIP_STATE_IDLE )
       {
         pstate->res = ELUA_NET_ERR_TIMEDOUT;
         pstate->state = ELUA_UIP_STATE_IDLE;
       }
-      platform_cpu_set_global_interrupts( old_status );
+      platform_cpu_exit_critical_section();
       break;
     }
   }
@@ -676,13 +676,13 @@ int old_status;
     return -1;
 #endif
 
-  old_status = platform_cpu_set_global_interrupts( PLATFORM_CPU_DISABLE );
+  platform_cpu_enter_critical_section();
 
   uip_unlisten( htons( port ) );
   if (flisten)
      uip_listen( htons( port ) );
 
-  platform_cpu_set_global_interrupts( old_status );
+  platform_cpu_exit_critical_section();
 
   return 0;
 
@@ -726,9 +726,9 @@ int elua_accept( u16 port, unsigned timer_id, timer_data_type to_us, elua_net_ip
     i=elua_net_find_pending( port );
     if( i >= 0 ) {
       *pfrom = elua_uip_accept_pending[i].remote;
-      old_status=platform_cpu_set_global_interrupts( PLATFORM_CPU_DISABLE );
+      platform_cpu_enter_critical_section();
       elua_uip_accept_pending[i].accept_request=0;
-      platform_cpu_set_global_interrupts( old_status );
+      platform_cpu_exit_critical_section();
       return elua_uip_accept_pending[i].sock;
     }
 

--- a/src/lua/lstate.c
+++ b/src/lua/lstate.c
@@ -232,13 +232,13 @@ lua_State *lua_getstate(void) {
 }
 LUA_API void lua_close (lua_State *L) {
 #ifndef LUA_CROSS_COMPILER  
-  int oldstate = platform_cpu_set_global_interrupts( PLATFORM_CPU_DISABLE );
+  platform_cpu_enter_critical_section();
   lua_sethook( L, NULL, 0, 0 );
   lua_crtstate = NULL;
   lua_pushnil( L );
   lua_rawseti( L, LUA_REGISTRYINDEX, LUA_INT_HANDLER_KEY );
   elua_int_cleanup();
-  platform_cpu_set_global_interrupts( oldstate );
+  platform_cpu_exit_critical_section();
   linenoise_cleanup( LINENOISE_ID_LUA );
 #endif  
   L = G(L)->mainthread;  /* only the main thread can be closed */

--- a/src/platform/arm_cortex_interrupts.c
+++ b/src/platform/arm_cortex_interrupts.c
@@ -9,6 +9,32 @@ extern void arm_enable_ints( void );
 extern void arm_disable_ints( void );
 extern u32 arm_get_int_status( void );
 
+static int critical_interrupts_enabled = 0;
+static int state_saved = 0;
+
+void platform_s_cpu_enter_critical_section( void )
+{
+  const int interrupt_state = platform_cpu_get_global_interrupts();
+  arm_disable_ints();
+  if( state_saved )
+  {
+    return;
+  }
+  critical_interrupts_enabled = interrupt_state;
+  state_saved = 1;
+}
+
+void platform_s_cpu_exit_critical_section( void )
+{
+  state_saved = 0;
+
+  // Restore the IRQs to their state prior to entering the critical section
+  if( critical_interrupts_enabled )
+  {
+    arm_enable_ints();
+  }
+}
+
 int platform_cpu_set_global_interrupts( int status )
 {
   u32 crt_status = arm_get_int_status();
@@ -24,4 +50,3 @@ int platform_cpu_get_global_interrupts( void )
 {
   return ( arm_get_int_status() & INTERRUPT_MASK_BIT ) == INTERRUPT_ACTIVE;
 }
-

--- a/src/platform/avr32/platform.c
+++ b/src/platform/avr32/platform.c
@@ -783,6 +783,32 @@ int platform_cpu_get_global_interrupts()
   return Is_global_interrupt_enabled();
 }
 
+static int critical_interrupts_enabled = 0;
+static int state_saved = 0;
+
+void platform_s_cpu_enter_critical_section( void )
+{
+  const int interrupt_state = Is_global_interrupt_enabled();
+  Disable_global_interrupt();
+  if( state_saved )
+  {
+    return;
+  }
+  critical_interrupts_enabled = interrupt_state;
+  state_saved = 1;
+}
+
+void platform_s_cpu_exit_critical_section( void )
+{
+  state_saved = 0;
+
+  // Restore the IRQs to their state prior to entering the critical section
+  if( critical_interrupts_enabled )
+  {
+    Enable_global_interrupt();
+  }
+}
+
 // ****************************************************************************
 // ADC functions
 

--- a/src/platform/i386/platform.c
+++ b/src/platform/i386/platform.c
@@ -175,12 +175,15 @@ timer_data_type platform_s_timer_op( unsigned id, int op, timer_data_type data )
 // ****************************************************************************
 // "Dummy" CPU functions
 
-int platform_cpu_set_global_interrupts( int status )
+void platform_s_cpu_enter_critical_section( void )
 {
-  return 0;
 }
 
-int platform_cpu_get_global_interrupts( void )
+void platform_s_cpu_exit_critical_section( void )
+{
+}
+
+int platform_cpu_set_global_interrupts( int status )
 {
   return 0;
 }

--- a/src/platform/sim/platform.c
+++ b/src/platform/sim/platform.c
@@ -167,14 +167,15 @@ timer_data_type platform_timer_read_sys( void )
 // ****************************************************************************
 // "Dummy" CPU functions
 
+void platform_s_cpu_enter_critical_section( void )
+{
+}
+
+void platform_s_cpu_exit_critical_section( void )
+{
+}
 
 int platform_cpu_set_global_interrupts( int status )
 {
   return 0;
 }
-
-int platform_cpu_get_global_interrupts( void )
-{
-  return 0;
-}
-


### PR DESCRIPTION
Critical sections are now used instead of the faulty disable/enable
interrupts mechanism. The critical section implementation was taken from
Mbed OS.
Virtual timers are still problematic, since they need to enable
interrupts explicitly for some of their operations. It's best to keep
their usage to a minimum.