### PR TITLE
Increased RRAM size

### DIFF
--- a/src/platform/sim3u1xx/sim3u167.ld
+++ b/src/platform/sim3u1xx/sim3u167.ld
@@ -1,7 +1,7 @@
 MEMORY
 {
-    sret (W!RX) : ORIGIN = 0x20000000, LENGTH = 0x0020
-    sram (W!RX) : ORIGIN = 0x20000020, LENGTH = 0x7FDF
+    sret (W!RX) : ORIGIN = 0x20000000, LENGTH = 0x0080
+    sram (W!RX) : ORIGIN = 0x20000080, LENGTH = 0x7F7F
     flash (RX) : ORIGIN = 0x00000000, LENGTH = 0x3fffc
 }
 

--- a/src/platform/sim3u1xx/sim3u167_freakusb.ld
+++ b/src/platform/sim3u1xx/sim3u167_freakusb.ld
@@ -1,7 +1,7 @@
 MEMORY
 {
-    sret (W!RX) : ORIGIN = 0x20000000, LENGTH = 0x0020
-    sram (W!RX) : ORIGIN = 0x20000020, LENGTH = 0x7FDF
+    sret (W!RX) : ORIGIN = 0x20000000, LENGTH = 0x0080
+    sram (W!RX) : ORIGIN = 0x20000080, LENGTH = 0x7F7F
     flash (RX) : ORIGIN = 0x00003000, LENGTH = 0x3CFFC
 }
 


### PR DESCRIPTION
Also updated FreakUSB to the latest version that uses the same RRAM size
(128 bytes).