### PR TITLE
Added large RRAM option for the build script

### DIFF
--- a/build_elua.lua
+++ b/build_elua.lua
@@ -124,6 +124,7 @@ builder:add_option( 'boot', 'boot mode, standard will boot to shell, luarpc boot
 builder:add_option( 'romfs', 'ROMFS compilation mode', 'verbatim', { 'verbatim' , 'compress', 'compile' } )
 builder:add_option( 'cpumode', 'ARM CPU compilation mode (only affects certain ARM targets)', nil, { 'arm', 'thumb' } )
 builder:add_option( 'bootloader', 'Build for bootloader usage', 'none', { 'none', 'emblod', 'freakusb' } )
+builder:add_option( 'large_rram', 'Use large RRAM (128 bytes) on GSatMicro (needs matching bootloader)', false)
 builder:add_option( 'debug', 'Enable debug build', false )
 builder:add_option( 'extras', 'Path to directory containing build extras', '' )
 builder:add_option( 'extrasconf', 'Config file for build extras, defaults to conf.lua', '' )

--- a/src/platform/sim3u1xx/conf.lua
+++ b/src/platform/sim3u1xx/conf.lua
@@ -29,11 +29,20 @@ specific_files = "platform.c platform_int.c pmu.c aes.c aes_config.c"
 
 -- Choose ldscript according to choice of bootloader
 if comp.bootloader == 'none' then
-  print "Compiling with standard offset"
-  ldscript = sf( "src/platform/%s/%s.ld", platform, comp.cpu:lower() )
+  if comp.large_rram then
+    print "Selecting large RRAM region (128 bytes)"
+    ldscript = sf( "src/platform/%s/%s_large_rram.ld", platform, comp.cpu:lower() )
+  else
+    ldscript = sf( "src/platform/%s/%s.ld", platform, comp.cpu:lower() )
+  end
 else
   print "Compiling for FreakUSB bootloader"
-  ldscript = sf( "src/platform/%s/%s_%s.ld", platform, comp.cpu:lower(), comp.bootloader )
+  if comp.large_rram then
+    print "Selecting large RRAM region (128 bytes)"
+    ldscript = sf( "src/platform/%s/%s_%s_large_rram.ld", platform, comp.cpu:lower(), comp.bootloader )
+  else
+    ldscript = sf( "src/platform/%s/%s_%s.ld", platform, comp.cpu:lower(), comp.bootloader )
+  end
   addm{ "USE_BOOTLOADER" }
 end
 

--- a/src/platform/sim3u1xx/sim3u167_freakusb.ld
+++ b/src/platform/sim3u1xx/sim3u167_freakusb.ld
@@ -1,7 +1,7 @@
 MEMORY
 {
-    sret (W!RX) : ORIGIN = 0x20000000, LENGTH = 0x0080
-    sram (W!RX) : ORIGIN = 0x20000080, LENGTH = 0x7F7F
+    sret (W!RX) : ORIGIN = 0x20000000, LENGTH = 0x0020
+    sram (W!RX) : ORIGIN = 0x20000020, LENGTH = 0x7FDF
     flash (RX) : ORIGIN = 0x00003000, LENGTH = 0x3CFFC
 }
 

--- a/src/platform/sim3u1xx/sim3u167_freakusb_large_rram.ld
+++ b/src/platform/sim3u1xx/sim3u167_freakusb_large_rram.ld
@@ -1,8 +1,8 @@
 MEMORY
 {
-    sret (W!RX) : ORIGIN = 0x20000000, LENGTH = 0x0020
-    sram (W!RX) : ORIGIN = 0x20000020, LENGTH = 0x7FDF
-    flash (RX) : ORIGIN = 0x00000000, LENGTH = 0x3fffc
+    sret (W!RX) : ORIGIN = 0x20000000, LENGTH = 0x0080
+    sram (W!RX) : ORIGIN = 0x20000080, LENGTH = 0x7F7F
+    flash (RX) : ORIGIN = 0x00003000, LENGTH = 0x3CFFC
 }
 
 SECTIONS
@@ -30,6 +30,7 @@ SECTIONS
     	__bss_section_table_end = .;
     	__section_table_end = . ;
     	/* End of Global Section Table */
+
 
     	*(.after_vectors*)
 
@@ -80,7 +81,7 @@ SECTIONS
 		} >sram
 		__exidx_end = .;
 
-    PROVIDE( flash_used_size = SIZEOF(.text) + SIZEOF(.data) + SIZEOF(.ARM.extab) + SIZEOF(.ARM.exidx) );
+    PROVIDE( flash_used_size = SIZEOF(.text) + SIZEOF(.data) + SIZEOF(.ARM.extab) + SIZEOF(.ARM.exidx) + 0x00003000 );
 
     .bss (NOLOAD) : {
 		. = ALIGN(4);

--- a/src/platform/sim3u1xx/sim3u167_large_rram.ld
+++ b/src/platform/sim3u1xx/sim3u167_large_rram.ld
@@ -1,7 +1,7 @@
 MEMORY
 {
-    sret (W!RX) : ORIGIN = 0x20000000, LENGTH = 0x0020
-    sram (W!RX) : ORIGIN = 0x20000020, LENGTH = 0x7FDF
+    sret (W!RX) : ORIGIN = 0x20000000, LENGTH = 0x0080
+    sram (W!RX) : ORIGIN = 0x20000080, LENGTH = 0x7F7F
     flash (RX) : ORIGIN = 0x00000000, LENGTH = 0x3fffc
 }
 


### PR DESCRIPTION
Added build option for large RRAM (0x80 bytes instead of 0x20 bytes).
Turned off by default.