### PR TITLE
Added cpu.uid() function

### DIFF
--- a/inc/platform.h
+++ b/inc/platform.h
@@ -256,6 +256,9 @@ u32 platform_pwm_get_clock( unsigned id );
 #define PLATFORM_INT_NOT_HANDLED        ( -3 )
 #define PLATFORM_INT_BAD_RESNUM         ( -4 )
 
+// Size of the CPU UID in bytes
+#define PLATFORM_CPU_UID_SIZE           16
+
 int platform_cpu_set_global_interrupts( int status );
 int platform_cpu_get_global_interrupts(void);
 void platform_cpu_enter_critical_section(void);
@@ -266,6 +269,7 @@ int platform_cpu_set_interrupt( elua_int_id id, elua_int_resnum resnum, int stat
 int platform_cpu_get_interrupt( elua_int_id id, elua_int_resnum resnum );
 int platform_cpu_get_interrupt_flag( elua_int_id id, elua_int_resnum resnum, int clear );
 u32 platform_cpu_get_frequency(void);
+int platform_cpu_get_uid( char *uid );
 
 // *****************************************************************************
 // The platform ADC functions

--- a/src/platform/sim3u1xx/platform.c
+++ b/src/platform/sim3u1xx/platform.c
@@ -41,6 +41,7 @@
 #include <SI32_SARADC_A_Type.h>
 #include <SI32_LDO_A_Type.h>
 #include <SI32_SPI_A_Type.h>
+#include <SI32_DEVICEID_A_Type.h>
 #include "myPB.h"
 #include <gVMON0.h>
 #include <gLDO0.h>
@@ -2875,3 +2876,20 @@ int sim3_usb_cdc_recv( s32 timeout )
 // }
 
 // #endif // #ifdef ENABLE_PMU
+
+// ****************************************************************************
+// CPU functions
+
+int platform_cpu_get_uid( char *uid )
+{
+  // From the datasheet, paragraph 11.2: "A 128-bit universally unique identifier
+  // (UUID) is pre-programmed into all devices. The UUID can be read by firmware
+  // at addresses 0x00040380 through 0x00040383.
+  const u32 *p_uuid = (const  u32* )0x00040380;
+  for ( int i = 0; i < 4; i ++, uid += sizeof( u32 ) ) {
+    u32 temp = p_uuid[ i ];
+    temp = __builtin_bswap32( temp ); // keep big endian representation in output buffer
+    memcpy( uid, &temp, sizeof( u32 ) );
+  }
+  return PLATFORM_OK;
+}


### PR DESCRIPTION
Added the cpu.uid() function that returns the CPU UID as a hexadecimal
string if it exists or nil otherwise. The UID size is 128 bits (16
bytes) of all platforms.

An example of the output this function:

```
> print(cpu.uid())
4D0000015531363700004D3300000000
```