### PR TITLE
Experimental feature: preprocess Lua files

### DIFF
--- a/utils/utils.lua
+++ b/utils/utils.lua
@@ -197,10 +197,10 @@ gen_header_string = function( name, defines )
 end
 
 -- Generate header with the given #defines, save result to file
-gen_header_file = function( name, defines )
+gen_header_file = function( name, defines, force_name )
   local hname = concat_path{ "inc", name:lower() .. ".h" }
   local h = assert( io.open( hname, "w" ) )
-  h:write( gen_header_string( name, defines ) )
+  h:write( gen_header_string( force_name or name, defines ) )
   h:close()
 end
 


### PR DESCRIPTION
If the builder script is invoked with `preprocess_romfs=true`, the code
will run the Lua source files through the C/C++ preprocessor before
processing them further.

The first advantage of this is that it can save some RAM. Assume that
there is a large list of Lua constants that must be used in the code:

```
addr_list = {CONST1: 10, CONST2: 20, ...}

set_data(addr_list.CONST1, 40)
set_data(addr_list.CONST2, 100)
...
```

If `addr_list` is large, it will take a lot of memory. With the
preprocessor on, it's possible to rewrite the code like this:

```
#define CONST1 10
#define CONST2 20

set_data(CONST1, 40)
set_data(CONST2, 100)
```

which will result in this final code:

```
set_data(10, 40)
set_data(20, 100)
```

which is smaller (and needs less memory) than the original code.

The second advatange is that it allows conditional code:

```
#ifdef BUILD_TIME_MACRO
call_function1()
#else
call_function2()
#endif
```