### PR TITLE
Changes for the improved object build environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ luarpc*
 *.functionsizes
 *.objdump
 wofs.img
+dist/
+GSatMicro/
+*.zip

--- a/inc/romfs.h
+++ b/inc/romfs.h
@@ -5,6 +5,7 @@
 
 #include "type.h"
 #include "devman.h"
+#include "romfs_common_defs.h"
 #include "platform_conf.h"
 
 /*******************************************************************************
@@ -32,10 +33,6 @@ enum
   FS_FILE_NOT_FOUND,
   FS_FILE_OK
 };
- 
-// ROMFS/WOFS functions
-typedef u32 ( *p_fs_read )( void *to, u32 fromaddr, u32 size, const void *pdata );
-typedef u32 ( *p_fs_write )( const void *from, u32 toaddr, u32 size, const void *pdata );
 
 // File flags
 #define ROMFS_FILE_FLAG_READ      0x01
@@ -60,23 +57,6 @@ typedef struct
 // of the filesystem (1) + the maximum number of bytes needed to align the contents 
 // of a file (3)
 #define WOFS_MIN_NEEDED_SIZE      11   
-
-// Filesystem flags
-#define ROMFS_FS_FLAG_DIRECT      0x01    // direct mode (the file is mapped in a memory area directly accesible by the CPU)
-#define ROMFS_FS_FLAG_WO          0x02    // this FS is actually a WO (Write-Once) FS
-#define ROMFS_FS_FLAG_WRITING     0x04    // for WO only: there is already a file opened in write mode
-#define ROMFS_FS_FLAG_READY_WRITE 0x08    // for WO only: filesystem consistency OK for writing
-#define ROMFS_FS_FLAG_READY_READ  0x10    // for WO only: filesystem consistency OK for reading
-
-// File system descriptor
-typedef struct
-{
-  u8 *pbase;                      // pointer to FS base in memory (only for ROMFS_FS_FLAG_DIRECT)
-  u8 flags;                       // flags (see above)
-  p_fs_read readf;                // pointer to read function (for non-direct mode FS)
-  p_fs_write writef;              // pointer to write function (only for ROMFS_FS_FLAG_WO)
-  u32 max_size;                   // maximum size of the FS (in bytes)
-} FSDATA;
 
 #define romfs_fs_set_flag( p, f )     (p)->flags |= ( f )
 #define romfs_fs_clear_flag( p, f )   (p)->flags &= ( u8 )~( f )

--- a/inc/romfs_common_defs.h
+++ b/inc/romfs_common_defs.h
@@ -1,0 +1,29 @@
+// Common definition for the ROM file system
+
+#ifndef __ROMFS_COMMON_DEFS_H__
+#define __ROMFS_COMMON_DEFS_H__
+
+#include "type.h"
+
+// Filesystem flags
+#define ROMFS_FS_FLAG_DIRECT      0x01    // direct mode (the file is mapped in a memory area directly accesible by the CPU)
+#define ROMFS_FS_FLAG_WO          0x02    // this FS is actually a WO (Write-Once) FS
+#define ROMFS_FS_FLAG_WRITING     0x04    // for WO only: there is already a file opened in write mode
+#define ROMFS_FS_FLAG_READY_WRITE 0x08    // for WO only: filesystem consistency OK for writing
+#define ROMFS_FS_FLAG_READY_READ  0x10    // for WO only: filesystem consistency OK for reading
+
+// ROMFS/WOFS functions
+typedef u32 ( *p_fs_read )( void *to, u32 fromaddr, u32 size, const void *pdata );
+typedef u32 ( *p_fs_write )( const void *from, u32 toaddr, u32 size, const void *pdata );
+
+// File system descriptor
+typedef struct
+{
+  u8 *pbase;                      // pointer to FS base in memory (only for ROMFS_FS_FLAG_DIRECT)
+  u8 flags;                       // flags (see above)
+  p_fs_read readf;                // pointer to read function (for non-direct mode FS)
+  p_fs_write writef;              // pointer to write function (only for ROMFS_FS_FLAG_WO)
+  u32 max_size;                   // maximum size of the FS (in bytes)
+} FSDATA;
+
+#endif

--- a/src/romfs.c
+++ b/src/romfs.c
@@ -2,7 +2,6 @@
 #include "romfs.h"
 #include <string.h>
 #include <errno.h>
-#include "romfiles.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include "ioctl.h"
@@ -549,14 +548,7 @@ static const DM_DEVICE romfs_device =
 // ****************************************************************************
 // ROMFS instance descriptor
 
-static const FSDATA romfs_fsdata =
-{
-  ( u8* )romfiles_fs,
-  ROMFS_FS_FLAG_DIRECT | ROMFS_FS_FLAG_READY_READ,
-  NULL,
-  NULL,
-  sizeof( romfiles_fs )
-};
+extern const FSDATA romfs_fsdata;
 
 // ****************************************************************************
 // WOFS functions and instance descriptor for the simulator (testing)

--- a/src/romfs_data.c
+++ b/src/romfs_data.c
@@ -1,0 +1,13 @@
+// All compile-time ROMFS data is keps in this file
+
+#include "romfs_common_defs.h"
+#include "romfiles.h"
+
+const FSDATA romfs_fsdata =
+{
+  ( u8* )romfiles_fs,
+  ROMFS_FS_FLAG_DIRECT | ROMFS_FS_FLAG_READY_READ,
+  NULL,
+  NULL,
+  sizeof( romfiles_fs )
+};

--- a/utils/utils.lua
+++ b/utils/utils.lua
@@ -10,6 +10,11 @@ local md5 = require "md5"
 dir_sep = package.config:sub( 1, 1 )
 is_os_windows = dir_sep == '\\'
 
+-- Returns true if the given argument is a table, false otherwise
+istable = function(e)
+  return type(e) == "table"
+end
+
 -- Converts a string with items separated by 'sep' into a table
 string_to_table = function( s, sep )
   if type( s ) ~= "string" then return end


### PR DESCRIPTION
Changes for the improved object build environment

These changes were made to better support the improved object build environment
and should have no effect on the existing functionality.

- Split ROMFS header into a common part (`inc/romfs_common_defs.h`) that will be provided
  in the object build environment. `inc/romfs.h` still exists, but doesn't need to be provided.
- Split ROMFS implementation into a common part ('src/romfs_data.c`) that will be provided
  in the object build environment. This is a very small source file that includes `romfiles.h`
  (which encodes all the files in ROMFS) and contains only the declaration of the
  `romfs_fsdata` variable (which fully defines the ROMFS in the implementation). `src/romfs.c`
  still contains the actual implementation of ROMFS, but doesn't include `romfiles.h` anymore,
  which makes it independent of the actual ROMFS content. `src/romfs.c` doesn't need to be
  provided.
- Fixed a missing function in `utils/utils.lua`